### PR TITLE
feat: implement thread-safe caching for avatars

### DIFF
--- a/lib/nameplate/avatar/cache.rb
+++ b/lib/nameplate/avatar/cache.rb
@@ -1,34 +1,58 @@
 # frozen_string_literal: true
 
+require "concurrent-ruby"
+require "fileutils"
+
 module NamePlate
   class Avatar
-    # Builds file paths for cached avatars.
+    # Thread-safe cache manager for avatar file paths.
     class Cache
-      # Returns the base path for cached avatars.
-      #
-      # @return [String] Base cache path.
-      def self.base_path
-        "#{NamePlate.cache_base_path || "public/system"}/nameplate/#{Avatar::VERSION}"
-      end
+      @cache = Concurrent::Map.new
 
-      # Builds the file path for a cached avatar.
-      #
-      # @param [Identity] identity The identity object representing the user.
-      # @param [Integer] size The size of the avatar.
-      # @return [String] The file path for the cached avatar.
-      def self.path(identity, size)
-        dir = File.join(base_path, identity.letters, identity.color.join("_"))
-        FileUtils.mkdir_p(dir)
-        File.join(dir, "#{size}.png")
-      end
+      class << self
+        # Returns the base path for cached avatars.
+        #
+        # @return [String] Base cache path.
+        def base_path
+          "#{NamePlate.cache_base_path || "public/system"}/nameplate/#{Avatar::VERSION}"
+        end
 
-      # Check if a cached avatar exists for the given identity and size.
-      #
-      # @param [Identity] identity The identity object representing the user.
-      # @param [Integer] size The size of the avatar.
-      # @return [Boolean] True if a cached avatar exists, false otherwise.
-      def self.cached?(identity, size)
-        File.exist?(path(identity, size))
+        # Builds or fetches the file path for a cached avatar.
+        #
+        # Uses a Concurrent::Map to ensure thread-safe memoization.
+        #
+        # @param [Identity] identity The identity object representing the user.
+        # @param [Integer] size The size of the avatar.
+        # @return [String] The file path for the cached avatar.
+        def path(identity, size)
+          key = cache_key(identity, size)
+
+          @cache.compute_if_absent(key) do
+            dir = File.join(base_path, identity.letters, identity.color.join("_"))
+            FileUtils.mkdir_p(dir)
+            File.join(dir, "#{size}.png")
+          end
+        end
+
+        # Check if a cached avatar exists for the given identity and size.
+        #
+        # @param [Identity] identity The identity object representing the user.
+        # @param [Integer] size The size of the avatar.
+        # @return [Boolean] True if a cached avatar exists, false otherwise.
+        def cached?(identity, size)
+          File.exist?(path(identity, size))
+        end
+
+        private
+
+        # Builds a unique cache key from identity + size.
+        #
+        # @param [Identity] identity
+        # @param [Integer] size
+        # @return [String]
+        def cache_key(identity, size)
+          "#{identity.letters}-#{identity.color.join("_")}-#{size}"
+        end
       end
     end
   end

--- a/nameplate.gemspec
+++ b/nameplate.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mini_magick", "~> 5.3"
+  spec.add_dependency "concurrent-ruby", "~> 1.3", ">= 1.3.5"
 end

--- a/sig/nameplate/avatar/generator.rbs
+++ b/sig/nameplate/avatar/generator.rbs
@@ -47,17 +47,14 @@ module NamePlate
 
       # Base class for avatar generation errors
       # @abstract
-      # @since 0.1.0
       class GenerationError < StandardError
       end
 
       # Raised when MiniMagick/ImageMagick fails to render an avatar.
-      # @since 0.1.0
       class ImageMagickError < GenerationError
       end
 
       # Raised when filesystem operations (write/verify) fail.
-      # @since 0.1.0
       class FileSystemError < GenerationError
       end
 

--- a/spec/nameplate/avatar/generator_spec.rb
+++ b/spec/nameplate/avatar/generator_spec.rb
@@ -6,16 +6,21 @@ RSpec.describe NamePlate::Avatar::Generator do
   let(:identity) { NamePlate::Avatar::Identity.new([226, 95, 81], "T") }
   let(:target_path) { File.expand_path("../../tmp/generated/64.png", __dir__) }
   let(:fake_font) { "/fake/font.ttf" }
+  let(:mm_cmd) do
+    double("MiniMagick::Command",
+      :size => nil, :<< => nil, :pointsize => nil, :font => nil,
+      :weight => nil, :fill => nil, :gravity => nil, :annotate => nil)
+  end
 
   before do
     # Never touch the filesystem
     allow(FileUtils).to receive(:mkdir_p)
     allow(FileUtils).to receive(:rm_f)
 
-    # Ensure MiniMagick constant exists even if the gem isn't loaded
+    # Stub MiniMagick constant if not loaded
     stub_const("MiniMagick", Module.new) unless defined?(MiniMagick)
 
-    # Avoid any real font lookups or file probes
+    # Avoid any real font lookups
     allow(NamePlate).to receive(:font).and_return(fake_font)
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with(fake_font).and_return(true)
@@ -29,34 +34,20 @@ RSpec.describe NamePlate::Avatar::Generator do
     it "returns cached path when file exists and cache=true" do
       allow(File).to receive(:exist?).with(target_path).and_return(true)
 
-      path = described_class.call("Tony", 64, cache: true)
-
-      expect(path).to eq(target_path)
+      expect(described_class.call("Tony", 64, cache: true)).to eq(target_path)
     end
 
     it "generates via MiniMagick when cache miss" do
       allow(File).to receive(:exist?).with(target_path).and_return(false)
-
-      mm_cmd = double("MiniMagick::Command",
-        :size => nil, :<< => nil, :pointsize => nil, :font => nil,
-        :weight => nil, :fill => nil, :gravity => nil, :annotate => nil)
-
       expect(MiniMagick).to receive(:convert).and_yield(mm_cmd)
 
-      path = described_class.call("Tony", 64, cache: false)
-
-      expect(path).to eq(target_path)
+      expect(described_class.call("Tony", 64, cache: false)).to eq(target_path)
     end
 
     it "caps size at Avatar::FULLSIZE" do
       allow(File).to receive(:exist?).with(target_path).and_return(false)
-
-      mm_cmd = double("MiniMagick::Command",
-        :size => nil, :<< => nil, :pointsize => nil, :font => nil,
-        :weight => nil, :fill => nil, :gravity => nil, :annotate => nil)
       allow(MiniMagick).to receive(:convert).and_yield(mm_cmd)
 
-      # Verify Cache.path receives the clamped size
       expect(NamePlate::Avatar::Cache).to receive(:path) do |_, s|
         expect(s).to eq(NamePlate::Avatar::FULLSIZE)
         target_path
@@ -66,15 +57,52 @@ RSpec.describe NamePlate::Avatar::Generator do
     end
   end
 
-  describe "input validation" do
-    it "raises when username is blank" do
-      expect { described_class.call(" ", 64) }
-        .to raise_error(described_class::ConfigurationError)
+  describe ".async_call" do
+    before do
+      # Always simulate cache miss
+      allow(File).to receive(:exist?).with(target_path).and_return(false)
     end
 
-    it "raises when size is not positive integer" do
-      expect { described_class.call("Tony", 0) }
-        .to raise_error(described_class::ConfigurationError)
+    let(:future) { described_class.async_call("Tony", 64) }
+
+    def stub_minimagick_success
+      allow(MiniMagick).to receive(:convert).and_yield(mm_cmd)
+    end
+
+    def stub_minimagick_failure(msg = "boom")
+      allow(MiniMagick).to receive(:convert).and_raise(msg)
+    end
+
+    it "returns a future that resolves to the avatar path" do
+      stub_minimagick_success
+      expect(future.value!).to eq(target_path)
+    end
+
+    it "wraps MiniMagick errors in ImageMagickError" do
+      stub_minimagick_failure
+      expect { future.value! }.to raise_error(described_class::ImageMagickError, /MiniMagick failed/)
+    end
+
+    it "wraps filesystem errors in FileSystemError" do
+      allow(NamePlate::Avatar::Cache).to receive(:path).and_raise(Errno::EACCES)
+      expect { future.value! }.to raise_error(described_class::FileSystemError, /Permission denied/)
+    end
+
+    it "wraps unexpected errors in GenerationError" do
+      allow(NamePlate::Avatar::Identity).to receive(:from_username).and_raise("weird failure")
+      expect { future.value! }.to raise_error(described_class::GenerationError, /Unexpected error/)
+    end
+  end
+
+  describe "input validation" do
+    [
+      {input: [" ", 64], error: described_class::ConfigurationError, description: "blank username"},
+      {input: ["Tony", 0], error: described_class::ConfigurationError, description: "non-positive size"},
+      {input: ["Tony", -5], error: described_class::ConfigurationError, description: "negative size"}
+    ].each do |test_case|
+      it "raises #{test_case[:error]} for #{test_case[:description]}" do
+        expect { described_class.call(*test_case[:input]) }.to raise_error(test_case[:error])
+      end
     end
   end
 end


### PR DESCRIPTION
Enhance the Avatar::Cache class to utilize Concurrent::Map for thread-safe caching of avatar file paths. Add methods for checking cached avatars and generating unique cache keys. Introduce async_call method in Avatar::Generator for non-blocking avatar generation.